### PR TITLE
fix: exclude auth routes from middleware to prevent redirect loops

### DIFF
--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -13,8 +13,10 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
-     * Feel free to modify this pattern to include more paths.
+     * - auth (authentication page)
+     * - api routes
+     * - public assets in the public folder
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|auth|api|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|json)$).*)',
   ],
 }


### PR DESCRIPTION
## Summary
- Fixed the production ERR_TOO_MANY_REDIRECTS error by excluding auth routes from middleware processing
- Added proper exclusions for auth, api routes, and additional static assets
- Prevents redirect loops when unauthenticated users try to access the auth page

## Changes
- Updated middleware matcher pattern to exclude `/auth` routes
- Added `/api` routes to exclusions for better API handling  
- Added additional file extensions (.ico, .json) to static asset exclusions

## Testing
- Tested locally: auth page is now accessible without redirect loops
- Main page still properly redirects unauthenticated users to auth
- No regression in authenticated user flow

## Issue
Fixes #189

🤖 Generated with [Claude Code](https://claude.ai/code)