### PR TITLE
fix: prevent client-side access to process.env in t3-env config

### DIFF
--- a/packages/web/env.ts
+++ b/packages/web/env.ts
@@ -94,9 +94,12 @@ export const env = createEnv({
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially
-   * useful for Docker builds.
+   * useful for Docker builds. We check if we're in a browser to avoid client-side errors.
    */
-  skipValidation: !!process.env.SKIP_ENV_VALIDATION,
+  skipValidation:
+    typeof window !== 'undefined'
+      ? false // Always validate on client-side
+      : !!process.env.SKIP_ENV_VALIDATION, // Only check on server-side
   /**
    * Makes it so that empty strings are treated as undefined. `SOME_VAR: z.string()` and
    * `SOME_VAR=''` will throw an error.


### PR DESCRIPTION
## Summary
- Fixed the root cause of "Attempted to access a server-side environment variable on the client" error
- The issue was in `env.ts` where `skipValidation` was directly accessing `process.env.SKIP_ENV_VALIDATION`

## Problem
The t3-env configuration in `env.ts` had:
```typescript
skipValidation: \!\!process.env.SKIP_ENV_VALIDATION
```

This was being evaluated when client components imported the env object, causing the error.

## Solution
Added browser environment check to prevent client-side access:
```typescript
skipValidation: typeof window \!== 'undefined' 
  ? false // Always validate on client-side
  : \!\!process.env.SKIP_ENV_VALIDATION // Only check on server-side
```

## Test plan
- [x] Run typecheck - passes
- [ ] Deploy to production
- [ ] Verify no more env variable access errors in browser console
- [ ] Confirm routing system initializes properly

This should be the final fix for #199.

🤖 Generated with [Claude Code](https://claude.ai/code)