### PR TITLE
fix: remove server-side NODE_ENV access in client component

### DIFF
--- a/packages/web/components/sync-provider-wrapper.tsx
+++ b/packages/web/components/sync-provider-wrapper.tsx
@@ -22,10 +22,10 @@ export function SyncProviderWrapper({ children }: SyncProviderWrapperProps) {
   }
 
   // In test mode, skip sync provider initialization
+  // We only check for dev-auth-bypass cookie on client-side since NODE_ENV is server-only
   const isTestMode =
-    env.NODE_ENV === 'test' ||
-    (typeof window !== 'undefined' &&
-      document.cookie.includes('dev-auth-bypass=true'))
+    typeof window !== 'undefined' &&
+    document.cookie.includes('dev-auth-bypass=true')
 
   const syncConfig: SyncConfig = {
     supabaseUrl:


### PR DESCRIPTION
## Description

This PR fixes a client-side environment variable access error in `sync-provider-wrapper.tsx`.

## Issue

Fixes #208

## Problem

The `sync-provider-wrapper.tsx` component was accessing `env.NODE_ENV` which is a server-only environment variable. This was causing the following error in production:

```
Error: ❌ Attempted to access a server-side environment variable on the client
```

## Solution

Since the component is marked with `'use client'`, we cannot access server-side environment variables. The `NODE_ENV` check has been removed, keeping only the client-side cookie check for test mode detection.

### Changes Made

- Removed `env.NODE_ENV === 'test'` check from the `isTestMode` condition
- Kept only the client-side `dev-auth-bypass` cookie check
- Added comment explaining why NODE_ENV cannot be used

## Testing

- The app should now load without environment variable access errors
- Test mode detection still works via the `dev-auth-bypass` cookie